### PR TITLE
Fix error updating student information

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -13,8 +13,8 @@ class StudentsController < ApplicationController
     updated = false
     ActiveRecord::Base.transaction do
       # TODO: could be better if we apply 'accepts_nested_attributes_for' at this point
-      @user.student_information.update(student_information)
       updated = @user.update(user_params)
+      @user.student_information.update(student_information)
     end
     if updated
       redirect_to student_url(@user), notice: "Profile was successfully updated."
@@ -30,14 +30,14 @@ class StudentsController < ApplicationController
   end
 
   def user_params
-    validate_input.except(:student_information)
+    validate_input.except(:student_information_attributes)
   end
 
   def student_information
-    validate_input[:student_information]
+    validate_input[:student_information_attributes]
   end
 
   def validate_input
-    params.require(:user).permit(:email, :password, student_information: [:tutor_name, :cellphone])
+    params.require(:user).permit(:email, :password, student_information_attributes: [:tutor_name, :cellphone])
   end
 end

--- a/app/views/students/_form.html.erb
+++ b/app/views/students/_form.html.erb
@@ -28,7 +28,7 @@
     
   <% if user.student_information %>
     
-    <%= form.fields_for :student_information do |row| %>
+    <%= form.fields_for :student_information_attributes do |row| %>
 
       <p>
         <strong>Ocupation:</strong>

--- a/test/controllers/students_controller_test.rb
+++ b/test/controllers/students_controller_test.rb
@@ -30,7 +30,10 @@ class StudentsControllerTest < ActionDispatch::IntegrationTest
 
   test "should update student" do
     patch student_url(@user), params: {
-      user: { email: users(:two).email, student_information: { tutor_name: "Duck Duck go", cellphone: "1234567890" } }
+      user: {
+        email: users(:two).email,
+        student_information_attributes: { tutor_name: "Duck Duck go", cellphone: "1234567890" }
+      }
     }
 
     assert_redirected_to student_url(@user)


### PR DESCRIPTION
## Description
- I found a bug when the student tried to updates his information.

## Solution
- Since I applyied accept_nested_attributes_for method in User model  was creating an error. Fixed changing the name of the params sending by update form.