### PR TITLE
Fix update status of debt when debt pending is cero

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,4 +8,9 @@ class ApplicationController < ActionController::Base
       root_path
     end
   end
+
+  rescue_from OverflowPaymentException do |e|
+    session[:return_to] ||= request.referer
+    redirect_to session.delete(:return_to), alert: e.message
+  end
 end

--- a/app/controllers/teachers/debts/payments_controller.rb
+++ b/app/controllers/teachers/debts/payments_controller.rb
@@ -9,9 +9,9 @@ module Teachers
       end
 
       def create
-        @payment = Payment.new(payment_params)
+        payment = PaymentsService.new(payment_params)
 
-        return redirect_to teacher_debts_url(@user), notice: "Payment was successfully applied." if @payment.save
+        return redirect_to teacher_debts_url(@user), notice: "Payment was successfully applied." if payment.apply
 
         render :new, status: :unprocessable_entity
       end

--- a/app/exceptions/overflow_payment_exception.rb
+++ b/app/exceptions/overflow_payment_exception.rb
@@ -1,0 +1,7 @@
+class OverflowPaymentException < StandardError
+  include ExceptionsConstants
+
+  def initialize(msg = OVERFLOW_PAYMENT_EXCEPTION)
+    super(msg)
+  end
+end

--- a/app/models/debt.rb
+++ b/app/models/debt.rb
@@ -4,7 +4,7 @@ class Debt < ApplicationRecord
   has_many :payment, dependent: :destroy
 
   validates :amount, :concept, :teacher, :student, presence: true
-  enum :status, { pending: "pending", paid: "paid" }, default: nil
+  enum :status, DEBTS_STATUS, default: nil
 
   def total_debt_payments
     payment.sum(:amount)

--- a/app/services/payments_service.rb
+++ b/app/services/payments_service.rb
@@ -1,0 +1,28 @@
+class PaymentsService
+  def initialize(payment_params)
+    @debt = Debt.find(payment_params[:debt_id])
+    @payment = Payment.new(payment_params)
+  end
+
+  def apply
+    validate_amount
+    ActiveRecord::Base.transaction do
+      update_debt_status
+      payment.save
+    end
+  end
+
+  private
+
+  attr_accessor :debt, :payment
+
+  def update_debt_status
+    return unless debt.debt_pending == payment.amount
+
+    debt.update(status: DEBTS_STATUS[:paid])
+  end
+
+  def validate_amount
+    raise OverflowPaymentException if payment.amount > debt.debt_pending
+  end
+end

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -17,3 +17,9 @@ BELTS_TEXT = {
 }.freeze
 
 PER_PAGE = 4
+
+DEBTS_STATUS = { pending: "pending", paid: "paid" }.freeze
+
+module ExceptionsConstants
+  OVERFLOW_PAYMENT_EXCEPTION = 'Payment is bigger that debt'.freeze
+end

--- a/test/services/payments_services_test.rb
+++ b/test/services/payments_services_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class PaymentsServiceTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+    @debt = debts(:one)
+  end
+
+  test "should initialize an object" do
+    assert PaymentsService.new({ amount: 10, debt_id: @debt.id })
+  end
+
+  test "should apply a payment" do
+    payment = PaymentsService.new({ amount: 10, debt_id: @debt.id })
+
+    assert payment.apply
+  end
+
+  test "should apply and update status when the debts is over" do
+    payment = PaymentsService.new({ amount: @debt.debt_pending, debt_id: @debt.id })
+
+    assert payment.apply
+    assert @debt.status, DEBTS_STATUS[:paid]
+  end
+
+  test "should raise overflow payment exception if the payment is bigger than the debt" do
+    payment = PaymentsService.new({ debt_id: @debt.id, amount: @debt.amount + 1 })
+
+    assert_raises(OverflowPaymentException) { payment.apply }
+  end
+end


### PR DESCRIPTION
## Description
When a payment is applied, id the debt is cover by this payment the status of the debt didn't change

## Changelog
- Add service to manage payment process.
- Add custom error to block payments bigger than debt.
- Test for all.